### PR TITLE
Posterior predictive distribution updated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybuc"
-version = "0.14.0"
+version = "0.14.1"
 description = "Fast estimation of Bayesian structural time series models via Gibbs sampling."
 authors = ["Devin D. Garcia"]
 license = "BSD 3-Clause"


### PR DESCRIPTION
- Logic for computing the posterior predictive distribution of the response variable has been updated to allow for smoothed or filtered predictions (it used to only be filtered).
- A new method has been added to BayesianUnobservedComponents, namely posterior_predictive_distribution().
- Documentation for the posterior predictive distribution has been updated