### PR TITLE
Update to posterior predictive distribution calculations

### DIFF
--- a/pybuc/statespace/durbin_koopman_smoother.py
+++ b/pybuc/statespace/durbin_koopman_smoother.py
@@ -106,8 +106,7 @@ def dk_smoother(y: np.ndarray,
                 state_error_covariance_matrix: np.ndarray,
                 init_state: np.ndarray,
                 init_state_plus: np.ndarray,
-                init_state_covariance: np.ndarray,
-                has_predictors: bool = False):
+                init_state_covariance: np.ndarray):
     """
 
     :param y: ndarray of dimension (n, 1), where n is the number of observations.
@@ -145,8 +144,6 @@ def dk_smoother(y: np.ndarray,
 
     :param init_state_covariance: ndarray of dimension (m, m). Data type must be float64.
     The initial state covariance matrix for the m state equations.
-
-    :param has_predictors: boolean. True if the model has static regression coefficients.
 
 
     :return: Named tuple with the following:


### PR DESCRIPTION
- Calculation of the posterior predictive distributions for the response and state have been changed to correct for wrong variance. For example, the posterior predictive distribution for the response *was* computed by sampling from

            N(Z(t).a(t), Z(t).P(t).Z(t)' + ResponseErrorVariance)

 But the term Z(t).P(t).Z(t)' for the variance is not necessary since we are conditioning on the known posterior samples of the parameters. Now sampling is done by drawing from

 y_tilde(t) | y(t), Z(t), a(t), ResponseErrorVariance ~ N(Z(t).a(t), ResponseErrorVariance)

 This same logic is applied to the posterior distribution of the state vector.
 - Removed the argument "has_predictors" from dk_smoother() method in durbin_koopman_smoother.py. It's no longer needed.
 - The default value for the "smoothed" argument in method BayesianUnobservedComponents.posterior_predictive_distribution() has changed from True to False. This is to reflect the fact that future values of the target are not known in advance of prediction.
 - Given the correction for the posterior predictive distribution of the filtered state, multiprocessing is no longer necessary. Draws are now taken from a univariate normal distribution instead of a multivariate one.
 - Documentation was updated regarding the posterior predictive calculations