### PR TITLE
Fixed computation of posterior predictive distributions based on filt…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybuc"
-version = "0.14.5"
+version = "0.14.6"
 description = "Fast estimation of Bayesian structural time series models via Gibbs sampling."
 authors = ["Devin D. Garcia"]
 license = "BSD 3-Clause"


### PR DESCRIPTION
…ered states

- The systematic variance of the response and state equations was not accounted for under filtered states. For example, before y(t) | y(t-1) was sampled from N(Z(t).a(t), ResponseErrorVariance). It should be y(t) | y(t-1) ~ N(Z(t).a(t) | t-1, Z(t).P(t).Z(t)' + ResponseErrorVariance). This is because the posterior of a(t|t-1) is not sampled directly; a(t|t=1,...,n) is. The systematic variance Z(t).P(t).Z(t)' must therefore be accounted for.