### PR TITLE
Updated methodology for sampling from the filtered state's posterior …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybuc"
-version = "0.14.6"
+version = "0.14.7"
 description = "Fast estimation of Bayesian structural time series models via Gibbs sampling."
 authors = ["Devin D. Garcia"]
 license = "BSD 3-Clause"


### PR DESCRIPTION
…predictive distribution

- The posterior distribution for the filtered state comes from a multivariate normal. Thus, to sample from the posterior, each sample was drawn from this multivariate distribution. This can take a lot of time, especially if the number of posterior samples is large. Multiprocessing was used to speed things up.
- Instead of using multiprocessing, the new code exploits the fact that a multivariate random normal can be expressed as affine transformation of univariate, standard normal random variables. Specifically, X ~ MVN(c, S) can be expressed as X = c + Vz, where V is the Cholesky decomposition of covariance matrix S, c is the mean of X, and z is a vector of N(0, 1) random variables.