### PR TITLE
Index checking on future predictor data updated

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -374,14 +374,14 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "6.1.0"
+version = "6.2.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "importlib_metadata-6.1.0-py3-none-any.whl", hash = "sha256:ff80f3b5394912eb1b108fcfd444dc78b7f1f3e16b16188054bd01cb9cb86f09"},
-    {file = "importlib_metadata-6.1.0.tar.gz", hash = "sha256:43ce9281e097583d758c2c708c4376371261a02c34682491a8e98352365aad20"},
+    {file = "importlib_metadata-6.2.0-py3-none-any.whl", hash = "sha256:8388b74023a138c605fddd0d47cb81dd706232569f56c9aca7d9c7fdb54caeba"},
+    {file = "importlib_metadata-6.2.0.tar.gz", hash = "sha256:9127aad2f49d7203e7112098c12b92e4fd1061ccd18548cdfdc49171a8c073cc"},
 ]
 
 [package.dependencies]

--- a/pybuc/buc.py
+++ b/pybuc/buc.py
@@ -2983,6 +2983,7 @@ class BayesianUnobservedComponents:
         else:
             self.future_time_index = np.arange(self.num_obs, self.num_obs + num_periods)
 
+        # Check and prepare future predictor data
         if self.has_predictors and future_predictors is not None:
             if not isinstance(future_predictors, (np.ndarray, list, tuple, pd.Series, pd.DataFrame)):
                 raise TypeError("The future_predictors array must be a NumPy array, list, tuple, Pandas Series, "
@@ -2993,17 +2994,16 @@ class BayesianUnobservedComponents:
                 else:
                     fut_pred = future_predictors.copy()
 
-                # Check and prepare future predictor data
                 # -- data types match across predictors and future_predictors
                 if not isinstance(fut_pred, self.predictors_type):
                     raise TypeError('Object types for predictors and future_predictors must match.')
 
+                if not isinstance(self.future_time_index, type(self.historical_time_index)):
+                    raise TypeError('The future_predictors and predictors indexes must be of the same type.')
+
                 else:
                     # -- if Pandas type, grab index and column names
                     if isinstance(fut_pred, (pd.Series, pd.DataFrame)):
-                        if not isinstance(self.future_time_index, type(self.historical_time_index)):
-                            raise TypeError('The future_predictors and predictors indexes must be of the same type.')
-
                         if not (fut_pred.index[:num_periods] == self.future_time_index).all():
                             raise ValueError('The future_predictors index must match the future time index '
                                              'implied by the last observed date for the response and the '

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybuc"
-version = "0.14.11"
+version = "0.14.12"
 description = "Fast estimation of Bayesian structural time series models via Gibbs sampling."
 authors = ["Devin D. Garcia"]
 license = "BSD 3-Clause"


### PR DESCRIPTION
- The index type for future predictor data passed to BayesianUnobservedComponents.forecast() is now checked regardless of object type (Pandas, NumPy, list, tuple). It used to only be checked if it was a Pandas object
- Update to pyproject.toml and poetry.lock