### PR TITLE
Update to default priors, Gibbs starting values for variance paramete…

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1333,14 +1333,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.0.2"
+version = "2.0.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "urllib3-2.0.2-py3-none-any.whl", hash = "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"},
-    {file = "urllib3-2.0.2.tar.gz", hash = "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc"},
+    {file = "urllib3-2.0.3-py3-none-any.whl", hash = "sha256:48e7fafa40319d358848e1bc6809b208340fafe2096f1725d05d67443d0483d1"},
+    {file = "urllib3-2.0.3.tar.gz", hash = "sha256:bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybuc"
-version = "0.14.16"
+version = "0.15.0"
 description = "Fast estimation of Bayesian structural time series models via Gibbs sampling."
 authors = ["Devin D. Garcia"]
 license = "BSD 3-Clause"


### PR DESCRIPTION
…rs, and added logic to reject unreasonable posterior samples

- Default variance priors for level and seasonality have been changed. Default shape and scale priors changed from 1e-6 and 1e-6, respectively, to 0.01 and (0.01 * std.dev(response))^2.
- Default variance prior for trend has been changed. Default shape and scale priors changed from 1e-6 and 1e-6, respectively, to 1 and 0.1 * (0.01 * std.dev(response))^2. This prior in particular is meant to guard against noise in the data that may result in overly aggressive future trend.
- Default initial Gibbs values for variance parameters have changed from (Shape Prior / (1 + Scale Prior)) to (0.01 * std.dev(response))^2.
- Sampling from the posterior has changed. Posterior samples where any of the variance parameters exceed var(y) are ignored.