### PR TITLE
Bug fix for default variance priors

### DIFF
--- a/examples/airline.py
+++ b/examples/airline.py
@@ -21,6 +21,7 @@ hold_out_size = 12
 # Create train and test sets
 y_train = air.iloc[:-hold_out_size]
 y_test = air.iloc[-hold_out_size:]
+y_train.iloc[50:61] = np.nan
 
 if __name__ == '__main__':
     ''' Fit the airline data using SARIMA(0,1,1)(0,1,1) '''
@@ -107,7 +108,7 @@ if __name__ == '__main__':
     plt.show()
 
     # Plot time series components
-    bayes_uc.plot_components(burn=mcmc_burn, smoothed=False)
+    bayes_uc.plot_components(burn=mcmc_burn, smoothed=True)
     plt.show()
 
     # Get and plot forecast

--- a/pybuc/buc.py
+++ b/pybuc/buc.py
@@ -1615,7 +1615,7 @@ class BayesianUnobservedComponents:
 
         n = self.num_obs
         q = self.num_stoch_states
-        var_y = np.var(self.response, ddof=1)
+        var_y = np.nanvar(self.response, ddof=1)
         default_shape_prior = 0.01
         default_scale_prior = (0.01 * np.sqrt(var_y)) ** 2
 
@@ -2677,7 +2677,7 @@ class BayesianUnobservedComponents:
         R = self.state_error_transformation_matrix
         H = self.state_sse_transformation_matrix
         X = self.predictors
-        var_y = np.var(self.response, ddof=1)
+        var_y = np.nanvar(self.response, ddof=1)
 
         # Bring in the model configuration from _model_setup()
         model = self._model_setup(response_var_shape_prior, response_var_scale_prior,
@@ -2780,7 +2780,6 @@ class BayesianUnobservedComponents:
 
         # Run Gibbs sampler
         s = 0
-        # for s in range(num_samp):
         while s < num_samp:
             if s < 1:
                 init_state_values = gibbs_iter0_init_state

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybuc"
-version = "0.15.0"
+version = "0.15.1"
 description = "Fast estimation of Bayesian structural time series models via Gibbs sampling."
 authors = ["Devin D. Garcia"]
 license = "BSD 3-Clause"


### PR DESCRIPTION
- The variance of the response is used to construct a default prior for level, trend, and seasonality in buc.py. The function used for calculating variance, however, did not account for NaN values. Accordingly, switched from np.var() to np.nanvar().
- Update to pyproject.toml