### PR TITLE
Bug fix to plot_trace()

### DIFF
--- a/pybuc/buc.py
+++ b/pybuc/buc.py
@@ -3569,8 +3569,8 @@ class BayesianUnobservedComponents:
         fig.set_size_inches(12, 10)
         row = 0
         for p in parameters:
-            histplot(post_dict[p][burn:], ax=ax[row, 0])
-            lineplot(post_dict[p][burn:], ax=ax[row, 1])
+            histplot(post_dict[p], ax=ax[row, 0])
+            lineplot(post_dict[p], ax=ax[row, 1])
             ax[row, 0].title.set_text(p)
             row += 1
 


### PR DESCRIPTION
- Trace plots were redundantly ignoring burned samples from posterior, resulting in artificially low sample counts in the trace plot.