### PR TITLE
Updated post_pred_dist() method to allow for different set of predictors

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -704,14 +704,14 @@ files = [
 
 [[package]]
 name = "more-itertools"
-version = "9.1.0"
+version = "10.0.0"
 description = "More routines for operating on iterables, beyond itertools"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "more-itertools-9.1.0.tar.gz", hash = "sha256:cabaa341ad0389ea83c17a94566a53ae4c9d07349861ecb14dc6d0345cf9ac5d"},
-    {file = "more_itertools-9.1.0-py3-none-any.whl", hash = "sha256:d2bc7f02446e86a68911e58ded76d6561eea00cddfb2a91e7019bbb586c799f3"},
+    {file = "more-itertools-10.0.0.tar.gz", hash = "sha256:cd65437d7c4b615ab81c0640c0480bc29a550ea032891977681efd28344d51e1"},
+    {file = "more_itertools-10.0.0-py3-none-any.whl", hash = "sha256:928d514ffd22b5b0a8fce326d57f423a55d2ff783b093bab217eda71e732330f"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybuc"
-version = "0.18.1"
+version = "0.18.2"
 description = "Fast estimation of Bayesian structural time series models via Gibbs sampling."
 authors = ["Devin D. Garcia"]
 license = "BSD 3-Clause"


### PR DESCRIPTION
- posterior_predictive_distribution() has been renamed to post_pred_dist() for brevity
- post_pred_dict() now accepts 'predictors' as argument. This is to allow the user to test sensitivity of the model's in-sample predictions to new predictor data.
- Docstrings updated/corrected to reflect previous changes to priors
- _ar_state_post_upd() method has been moved inside BayesianUnobservedComponents as a static method
- _simulate_posterior_predictive_response() has been removed as it's no longer needed. post_pred_dist() takes its place.