### PR TITLE
Added plot_post_pred_dist() method to BayesianUnobservedComponents

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Black">
+    <option name="executionMode" value="BINARY" />
+    <option name="pathToExecutable" value="$USER_HOME$/.local/bin/black" />
+    <option name="sdkUUID" value="b518fe32-85ad-491a-900d-a6839d34ac65" />
+  </component>
   <component name="ProjectRootManager" version="2" project-jdk-name="Poetry (pybuc) (7)" project-jdk-type="Python SDK" />
 </project>

--- a/README.md
+++ b/README.md
@@ -238,10 +238,8 @@ for key, value in bayes_uc.summary(burn=mcmc_burn).items():
     print(key, ' : ', value)
 
 # Plot in-sample fit against actuals
-yhat = np.mean(post.filtered_prediction[mcmc_burn:], axis=0)
-plt.plot(y_train)
-plt.plot(y_train.index, yhat)
-plt.title('Bayesian-UC: In-sample')
+bayes_uc.plot_post_pred_dist(burn=mcmc_burn)
+plt.title('Bayesian UC: In-sample')
 plt.show()
 
 # Plot time series components
@@ -270,7 +268,7 @@ print(f"BAYES-UC RMSE: {rmse(y_test.to_numpy(), forecast_mean)}")
 ```
 
 ```
-BAYES-UC RMSE: 16.686702600845987
+BAYES-UC RMSE: 16.620400857034113
 ```
 
 The Bayesian Unobserved Components forecast plot, components plot, and RMSE are shown below.

--- a/examples/airline.py
+++ b/examples/airline.py
@@ -100,9 +100,7 @@ if __name__ == '__main__':
         print(key, ' : ', value)
 
     # Plot in-sample fit against actuals
-    yhat = np.mean(post.filtered_prediction[mcmc_burn:], axis=0)
-    plt.plot(y_train)
-    plt.plot(y_train.index, yhat)
+    bayes_uc.plot_post_pred_dist(burn=mcmc_burn)
     plt.title('Bayesian UC: In-sample')
     plt.show()
 
@@ -115,7 +113,8 @@ if __name__ == '__main__':
     plt.show()
 
     # Get and plot forecast
-    forecast, _ = bayes_uc.forecast(hold_out_size, mcmc_burn)
+    forecast, _ = bayes_uc.forecast(num_periods=hold_out_size,
+                                    burn=mcmc_burn)
     forecast_mean = np.mean(forecast, axis=0)
     forecast_l95 = np.quantile(forecast, 0.025, axis=0).flatten()
     forecast_u95 = np.quantile(forecast, 0.975, axis=0).flatten()

--- a/examples/simulated_regression.py
+++ b/examples/simulated_regression.py
@@ -111,9 +111,7 @@ if __name__ == '__main__':
         print(key, ' : ', value)
 
     # Plot in-sample fit against actuals
-    yhat = np.mean(post.filtered_prediction[mcmc_burn:], axis=0)
-    plt.plot(y_train)
-    plt.plot(yhat)
+    bayes_uc.plot_post_pred_dist(burn=mcmc_burn)
     plt.title('Bayesian-UC: In-sample')
     plt.show()
 
@@ -126,7 +124,9 @@ if __name__ == '__main__':
     plt.show()
 
     # Get and plot forecast
-    forecast, _ = bayes_uc.forecast(hold_out_size, mcmc_burn, future_predictors=x_test)
+    forecast, _ = bayes_uc.forecast(num_periods=hold_out_size,
+                                    burn=mcmc_burn,
+                                    future_predictors=x_test)
     forecast_mean = np.mean(forecast, axis=0)
     forecast_l95 = np.quantile(forecast, 0.025, axis=0).flatten()
     forecast_u95 = np.quantile(forecast, 0.975, axis=0).flatten()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1126,14 +1126,14 @@ idna2008 = ["idna"]
 
 [[package]]
 name = "rich"
-version = "13.4.2"
+version = "13.5.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 category = "main"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "rich-13.4.2-py3-none-any.whl", hash = "sha256:8f87bc7ee54675732fa66a05ebfe489e27264caeeff3728c945d25971b6485ec"},
-    {file = "rich-13.4.2.tar.gz", hash = "sha256:d653d6bccede5844304c605d5aac802c7cf9621efd700b46c7ec2b51ea914898"},
+    {file = "rich-13.5.0-py3-none-any.whl", hash = "sha256:996670a7618ccce27c55ba6fc0142e6e343773e11d34c96566a17b71b0e6f179"},
+    {file = "rich-13.5.0.tar.gz", hash = "sha256:62c81e88dc078d2372858660e3d5566746870133e51321f852ccc20af5c7e7b2"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pybuc"
-version = "0.18.2"
+version = "0.18.3"
 description = "Fast estimation of Bayesian structural time series models via Gibbs sampling."
 authors = ["Devin D. Garcia"]
 license = "BSD 3-Clause"


### PR DESCRIPTION
- Method for plotting the posterior predictive distribution of the response variable has been added.
- Updated README.md, pyproject.toml, pypoetry.lock, airline.py, and simulated_regression.py to reflect changes.